### PR TITLE
Update base image to Go 1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6-alpine
+FROM golang:1.8.3-alpine3.6
 MAINTAINER Nathan Craddock <nkcraddock@gmail.com>
 
 RUN set -ex \


### PR DESCRIPTION
The `jfrog` CLI uses some functions from the standard library which aren't present in Go version 1.6. This updates a newer version of Go so the image can build without error.